### PR TITLE
Specify FPU architecture in toolchain

### DIFF
--- a/sources/cmake-toolchain/Toolchain/common-3.0.cmake
+++ b/sources/cmake-toolchain/Toolchain/common-3.0.cmake
@@ -16,7 +16,7 @@ endif()
 string(REPLACE ";" " -arch " ARCH_FLAGS "-arch ${CMAKE_ARCHITECTURES}")
 
 set(CMAKE_C_FLAGS_INIT
-    "-isysroot ${SDK_PATH} -B${SDK_PATH}/usr/bin ${ARCH_FLAGS} -Wno-incompatible-sysroot -mlinker-version=253 -nodefaultlibs"
+    "-isysroot ${SDK_PATH} -B${SDK_PATH}/usr/bin ${ARCH_FLAGS} -Wno-incompatible-sysroot -mlinker-version=253 -nodefaultlibs -mfpu=vfpv2"
 )
 
 set(CMAKE_FIND_ROOT_PATH ${SDK_PATH})


### PR DESCRIPTION
Windows and linux will default to different FPU architectures which will result in different binaries. This helps builds be more consistent on different platforms.