### PR TITLE
Allow libc stub generator to accept multiple inputs

### DIFF
--- a/sources/libc-stub/generate_stub.py
+++ b/sources/libc-stub/generate_stub.py
@@ -4,35 +4,44 @@ import argparse
 
 from pathlib import Path
 
-from typing import List
+from typing import List, Set
 
-def generate_stub(input_file: Path | str, output_file: Path | str) -> None:
-    input_file, output_file = Path(input_file), Path(output_file)
 
-    with open(input_file, "r") as f:
-        symbols: List[str] = f.readlines()
+def generate_stub(input_files: List[Path | str], output_file: Path | str) -> None:
+    input_files, output_file = [Path(file) for file in input_files], Path(output_file)
 
-    symbols = [f"void {symbol[1:].strip()}() {{}}\n" for symbol in symbols]
+    symbols: Set[str] = set()
+    for input_file in input_files:
+        with open(input_file, "r") as f:
+            file_symbols: List[str] = f.readlines()
+        for symbol in file_symbols:
+            if symbol in symbols:
+                print(f"WARN: Duplicate symbol ({symbol.strip()}) found in {input_file}.")
+            symbols.add(symbol)
+
+    stub_functions: List[str] = [
+        f"void {symbol[1:].strip()}() {{}}\n" for symbol in symbols
+    ]
+    stub_functions.sort()
 
     with open(output_file, "w", encoding="utf-8") as f:
-        f.writelines(symbols)
+        f.writelines(stub_functions)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Convert a list of symbols to a stub c file"
     )
     parser.add_argument(
-        "symbol_list",
+        "symbol_lists",
         help="A list of symbols to use to generate a stub c file",
-        type=Path
+        type=Path,
+        nargs="+",
     )
-    parser.add_argument(
-        "output",
-        help="Output file name.",
-        type=Path
-    )
+    parser.add_argument("output", help="Output file name.", type=Path)
     args = parser.parse_args()
-    generate_stub(args.symbol_list, args.output)
+    generate_stub(args.symbol_lists, args.output)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is easier to maintain than a custom function and also plays better with formatting tools. It will cause warnings on macos but it should compile correctly regardless.