### PR TITLE
Simplify cmake toolchain

### DIFF
--- a/sources/cmake-toolchain/Toolchain/common-3.0.cmake
+++ b/sources/cmake-toolchain/Toolchain/common-3.0.cmake
@@ -2,7 +2,7 @@ get_filename_component(SDK_PATH "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 set(SDK_PATH "${SDK_PATH}" CACHE PATH "SDK installation path" FORCE)
 list(APPEND CMAKE_MODULE_PATH "${SDK_PATH}/cmake")
 
-set(CMAKE_SYSTEM_NAME common-3.0)
+set(CMAKE_SYSTEM_NAME darwin)
 set(CMAKE_SYSTEM_VERSION 3.0)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
@@ -18,14 +18,10 @@ endif()
 
 set(CMAKE_C_COMPILER_TARGET arm-apple-ios3.0)
 
-if(NOT CMAKE_ARCHITECTURES)
-    set(CMAKE_ARCHITECTURES "armv6;armv7")
-endif()
-
-string(REPLACE ";" " -arch " ARCH_FLAGS "-arch ${CMAKE_ARCHITECTURES}")
-
 set(CMAKE_C_FLAGS_INIT
-    "-B${SDK_PATH}/usr/bin ${ARCH_FLAGS} -Wno-incompatible-sysroot -mlinker-version=253 -mfpu=vfpv2"
+    "-B${SDK_PATH}/usr/bin -Wno-incompatible-sysroot -mlinker-version=253 -mfpu=vfpv2"
 )
 
 set(CMAKE_FIND_ROOT_PATH ${SDK_PATH})
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
By changing the system name to darwin we can now take advantage of properties like INSTALL_NAME_DIR and OSX_ARCHITECTURES instead of having to manually specify them in the toolchain.

Setting the static_library type skips linking to crt files which causes issues as the test program compiles for armv4 by default.